### PR TITLE
Client side Password Validation pt.4

### DIFF
--- a/login/src/main/resources/templates/web/pw_validation.html
+++ b/login/src/main/resources/templates/web/pw_validation.html
@@ -19,10 +19,10 @@
             // In case the policy equals to null, initialize the values to 0.
             var specialCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getRequireSpecialCharacter()}]]*/;
             var uppercaseCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getRequireUpperCaseCharacter()}]]*/;
-            var uppercaseCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getRequireLowerCaseCharacter()}]]*/;
+            var lowercaseCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getRequireLowerCaseCharacter()}]]*/;
             var numberCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getRequireDigit()}]]*/;
             var lengthCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getMinLength()}]]*/;
-            validatePassword(specialCount, uppercaseCount, uppercaseCount,
+            validatePassword(specialCount, uppercaseCount, lowercaseCount,
                               numberCount, lengthCount,
                               /*[[${passwordField}]]*/,
                               /*[[${confirmPasswordField}]]*/


### PR DESCRIPTION
Fix bug where uppercaseCount was the same value as lowercaseCount
Bug was introduced after refactor from pt.3
Work card:
https://trello.com/c/tc2CAVkh/439-ui-changing-setting-password-should-show-requirements-beforehand
