### PR TITLE
[Cloud.Gov] Fixes unit tests for invite.

### DIFF
--- a/login/src/main/resources/templates/mail/invite.html
+++ b/login/src/main/resources/templates/mail/invite.html
@@ -53,7 +53,7 @@
 </ul>
 </p>
 <p>
-  That's it! You're ready to use the platform. Cloud Foundry is well-documented
+  That's it! You're ready to use the platform. The platform is well-documented
   at <a href="https://docs.cloudfoundry.org">https://docs.cloudfoundry.org</a>,
   and documentation about <th:block th:text="${serviceName}"></th:block> in particular is
   located <a href="http://service.example.com/docs"


### PR DESCRIPTION
The tests assert that text does not contain Cloud Foundry in the case
that the brand is Pivotal. This fixes that conflict by just generalizing
to "The platform"
