### PR TITLE
Trim badges that display status of upstream repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 <link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link>
 # CloudFoundry User Account and Authentication (UAA) Server
 
-[![Build Status](https://travis-ci.org/cloudfoundry/uaa.svg?branch=develop)](https://travis-ci.org/cloudfoundry/uaa)
-[![Coverage Status](https://coveralls.io/repos/cloudfoundry/uaa/badge.png?branch=develop)](https://coveralls.io/r/cloudfoundry/uaa?branch=develop)
-
 The UAA is a multi tenant identity management service, used in Cloud Foundry, but also available
 as a stand alone OAuth2 server.  It's primary role is as an OAuth2 provider, issuing tokens for client
 applications to use when they act on behalf of Cloud Foundry users.


### PR DESCRIPTION
To minimize potential confusion for people looking at this fork, this removes the Travis and Coveralls badges that display status for the `cloudfoundry/uaa` repository.