### PR TITLE
Update warning: East-West is deprecated

### DIFF
--- a/server/src/main/resources/templates/web/eastwest/login.html
+++ b/server/src/main/resources/templates/web/eastwest/login.html
@@ -45,10 +45,10 @@
         <div class="alert alert-danger">
           <div class="panel-body">
             <h4 class="h4-primary">
-              IMPORTANT: This hosting environment will be shut down this month.
+              IMPORTANT: This hosting environment has been deprecated and will be shut down imminently.
             </h4>
             <p>
-              If you haven't already <a href="https://cloud.gov/docs/apps/govcloud/#migration" style="color: white; text-decoration: underline;">migrated your app(s)</a> to the new GovCloud hosting environment, please do so by March 15th.
+              Anything here, including applications, accounts, and organizations will soon be deleted without further notice.
             </p>
             <p>
               Questions? Contact <a href="mailto:cloud-gov-support@gsa.gov" style="color: white; text-decoration: underline;">cloud-gov-support@gsa.gov</a>.


### PR DESCRIPTION
To be deployed on March 16th, when the migration deadline will have passed.

This intentionally removes the link to the migration documentation. Why? Because if someone still has apps on East/West at this point, we want them to reach out to us, not silently start migrating their apps and risk losing them.

Related tickets:
* https://github.com/18F/cg-uaa/pull/40
* https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-3594